### PR TITLE
WIP: Change Module name to be loaded when launch rserver

### DIFF
--- a/roles/ood_add_rstudio/templates/form.yml
+++ b/roles/ood_add_rstudio/templates/form.yml
@@ -44,5 +44,5 @@ attributes:
     options:
       # Define functioning R version overloads using a colon after the module load statement
 {% for ver in r_versions %}
-      - [ "{{ ver.full }}", "rc/rserver/{{ ver.full }}"]
+      - [ "{{ ver.full }}", "rc/ood_rstudio/{{ ver.full }}"]
 {% endfor %}


### PR DESCRIPTION
Put rstudio example module file on Cheaha provided by OSC
  with name rc/ood_rstudio/VERSIONS