### PR TITLE
Change module intialization for jupyter to standard syntax

### DIFF
--- a/roles/ood_jupyter/templates/jupyter-script.sh.erb
+++ b/roles/ood_jupyter/templates/jupyter-script.sh.erb
@@ -2,7 +2,7 @@
 
 # Set working directory to home directory
 cd "${HOME}"
-module use {{ easybuild_prefix }}/modules/all
+module reset
 #
 # Start Jupyter Notebook Server
 #


### PR DESCRIPTION
Use the standard lmod mechanism to reset the module environment to the system default and avoid hard coded dependency on local paths.