### PR TITLE
Add explicit reference to Anaconda with jupyter support

### DIFF
--- a/roles/ood_jupyter/templates/custom-jupyter-form.yml
+++ b/roles/ood_jupyter/templates/custom-jupyter-form.yml
@@ -38,7 +38,7 @@ attributes:
     label: Environment Setup
     value: |
       # Load required modules
-      module load Anaconda3
+      module load Anaconda3/5.2.0
 
   # Whether Conda extensions will be available within the Jupyter notebook
   # server


### PR DESCRIPTION
Use explicit anaconda version that has the right modules for jupyter notebook support.