### PR TITLE
Feat ood shell config prod

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -70,6 +70,7 @@
   ood_nodename: "ood"
   ood_ip_addr: 10.1.1.254
   ood_provision: true
+  ood_shell_default_host: "cheaha.rc.uab.edu"
 
 #Node Inventory - not in the Ansible inventory sense! Just for WW and Slurm config.
 # Someday I will need a role that can run wwnodescan, and add nodes to this file! Probably horrifying practice.

--- a/roles/ood_uab_ui/tasks/main.yaml
+++ b/roles/ood_uab_ui/tasks/main.yaml
@@ -9,6 +9,7 @@
     - dashboard
     - activejobs
     - myjobs
+    - shell
 
 - name: Add shared directories into files menu
   template:

--- a/roles/ood_uab_ui/templates/shell/env_local.j2
+++ b/roles/ood_uab_ui/templates/shell/env_local.j2
@@ -1,0 +1,1 @@
+DEFAULT_SSHHOST="{{ ood_shell_default_host }}"


### PR DESCRIPTION
To fix ood shell opens different host, explicitly set the default ssh host in ood shell application config file, e.g. `/var/www/ood/apps/sys/shell/.env.local`.

In OOD ver 1.5, they move all of the config files to under `/etc/ood/config/apps/APP_NAME` so after we upgrade to ver 1.5, need to change this path as well.