### PR TITLE
Set default for matlab app to true

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -112,7 +112,7 @@
   easybuild_sourcepath: "/tmp/source"
 
 #matlab install related
-  matlab_provision: false
+  matlab_provision: true
   matlab_download_url: "https://uab.box.com/shared/static/y01qu7oo1gpne6j2s6nqwcuee63epivo.gz"
   matlab_clustershare: "/opt/ohpc/pub/apps/matlab/"
   matlab_destination: "/tmp/matlab.tar.gz"


### PR DESCRIPTION
The matlab app should deploy to prod by default.  Set the
groups_var/all feature var to true.