### PR TITLE
Fix uab_ood_auth.regex to handle all string patterns for accounts

### DIFF
--- a/roles/ood_auth_regex/files/uab_ood_auth.regex
+++ b/roles/ood_auth_regex/files/uab_ood_auth.regex
@@ -42,13 +42,24 @@ class Regex < OodAuthMap
   end
 
   define_run do |auth_user|
-    user_check_ori = `getent passwd #{auth_user} | cut -d : -f 1`
-    user_check_low = `getent passwd #{auth_user.downcase} | cut -d : -f 1`
-    if user_check_ori != "" || user_check_low != ""
-      puts auth_user.downcase
+    if sys_user = Helpers.parse_string(auth_user, /#{options[:regex]}/)
+      user_check_ori = `getent passwd #{sys_user} | cut -d : -f 1`
+      user_check_low = `getent passwd #{sys_user.downcase} | cut -d : -f 1`
+      if user_check_ori != "" || user_check_low != ""
+        puts sys_user.downcase
+      else
+        puts ""
+        exit(false)
+      end
     else
-      puts ""
-      exit(false)
+      user_check_ori = `getent passwd #{auth_user} | cut -d : -f 1`
+      user_check_low = `getent passwd #{auth_user.downcase} | cut -d : -f 1`
+      if user_check_ori != "" || user_check_low != ""
+        puts auth_user.downcase
+      else
+        puts ""
+        exit(false)
+      end
     end
   end
 end


### PR DESCRIPTION
Add two blocks to handle the regex command-line replacement string and the cases
where that string is not part of the username pattern. 
There is likely a more efficient approach to handle these two cases rather than repeating large
blocks of code.