### PR TITLE
Patch add GPU support to matlab

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -39,7 +39,7 @@
   nvidia_driver_installer: "NVIDIA-Linux-x86_64-387.26.run"
   cuda_toolkit_installer: "cuda-linux.9.1.85-23083092.run"
   cuda_samples_installer: "cuda-samples.9.1.85-23083092-linux.run"
-
+  cuda_toolkit_module: "cuda92/toolkit"
 
 # WW Template Names for wwmkchroot
   template_path: "/usr/libexec/warewulf/wwmkchroot/"

--- a/group_vars/all
+++ b/group_vars/all
@@ -39,7 +39,7 @@
   nvidia_driver_installer: "NVIDIA-Linux-x86_64-387.26.run"
   cuda_toolkit_installer: "cuda-linux.9.1.85-23083092.run"
   cuda_samples_installer: "cuda-samples.9.1.85-23083092-linux.run"
-  cuda_toolkit_module: "cuda92/toolkit"
+  cuda_toolkit_module: "cuda10.0/toolkit"
 
 # WW Template Names for wwmkchroot
   template_path: "/usr/libexec/warewulf/wwmkchroot/"

--- a/roles/ood_matlab/files/script.sh.erb
+++ b/roles/ood_matlab/files/script.sh.erb
@@ -24,6 +24,10 @@ cd "${HOME}"
 # Start MATLAB
 #
 
+<%- if context.bc_partition == "pascalnodes" -%>
+# Load CUDA toolkit
+module load <%= context.cuda_toolkit %>
+<%- end -%>
 # Load the required environment
 module load <%= context.version %>
 # Launch MATLAB

--- a/roles/ood_matlab/templates/form.yml
+++ b/roles/ood_matlab/templates/form.yml
@@ -39,6 +39,8 @@ attributes:
       - [ "{{ ver }}", "{{ matlab_module_name }}/{{ ver }}"]
 {% endfor %}
 
+  cuda_toolkit: "{{ cuda_toolkit_module }}"
+
 form:
   - version
   - bc_num_hours
@@ -46,3 +48,4 @@ form:
   - bc_num_slots
   - bc_num_mems
   - bc_email_on_started
+  - cuda_toolkit


### PR DESCRIPTION
Automatically load cuda toolkit when user chose to run matlab on pascalnodes.
Version of cuda toolkit is defined in `group_vars/all`