### PR TITLE
Update uab_ood_auth regex file

### DIFF
--- a/roles/ood_auth_regex/files/uab_ood_auth.regex
+++ b/roles/ood_auth_regex/files/uab_ood_auth.regex
@@ -5,7 +5,7 @@ require 'ood_auth_map'
 
 class Regex < OodAuthMap
   # Default regular expression to use when parsing authenticated username
-  DEFAULT_REGEX = "^(.+)$"
+  DEFAULT_REGEX = "^(.+)@uab(mc)?.edu$"
 
   # Body of option parser
   define_body do |parser|
@@ -42,10 +42,12 @@ class Regex < OodAuthMap
   end
 
   define_run do |auth_user|
-    user_check_ori = `getent passwd #{auth_user} | cut -d : -f 1`
-    user_check_low = `getent passwd #{auth_user.downcase} | cut -d : -f 1`
-    if user_check_ori != "" || user_check_low != ""
-      puts auth_user.downcase
+    sys_user = Helpers.parse_string(auth_user, /#{options[:regex]}/)
+    # downcase the result
+    sys_user = ( sys_user || auth_user ).downcase
+
+    if `getent passwd #{sys_user} | cut -d \' \' -f 1` != ""
+      puts sys_user
     else
       puts ""
       exit(false)

--- a/roles/ood_auth_regex/tasks/main.yaml
+++ b/roles/ood_auth_regex/tasks/main.yaml
@@ -17,3 +17,12 @@
 - name: Build the updated Apache config
   command: /opt/ood/ood-portal-generator/sbin/update_ood_portal
   ignore_errors: yes
+
+- name: Regex test cases
+  include_tasks: testing.yaml
+  vars:
+    test_str: "{{ item.test_str }}"
+    expected: "{{ item.expected }}"
+  with_items:
+    - { test_str: "louistw@uab.edu", expected: "louistw" }
+    - { test_str: "LoUiStW@uab.edu", expected: "louistw" }

--- a/roles/ood_auth_regex/tasks/main.yaml
+++ b/roles/ood_auth_regex/tasks/main.yaml
@@ -13,6 +13,7 @@
     owner: root
     group: root
     mode: 0755
+    backup: yes
 
 - name: Build the updated Apache config
   command: /opt/ood/ood-portal-generator/sbin/update_ood_portal

--- a/roles/ood_auth_regex/tasks/main.yaml
+++ b/roles/ood_auth_regex/tasks/main.yaml
@@ -3,7 +3,7 @@
   replace:
     path: /etc/ood/config/ood_portal.yml
     regexp: "^#?(user_map_cmd:).*"
-    replace: "\\1 \"/opt/ood/ood_auth_map/bin/uab_ood_auth.regex -r '^(.+)@uab.edu$'\""
+    replace: "\\1 \"/opt/ood/ood_auth_map/bin/uab_ood_auth.regex\""
     backup: yes
 
 - name: Stage regex file for ood

--- a/roles/ood_auth_regex/tasks/main.yaml
+++ b/roles/ood_auth_regex/tasks/main.yaml
@@ -27,3 +27,6 @@
   with_items:
     - { test_str: "louistw@uab.edu", expected: "louistw" }
     - { test_str: "LoUiStW@uab.edu", expected: "louistw" }
+    - { test_str: "FaKeAcCoUnT@uab.edu", expected: "" }
+    - { test_str: "rtripath89@gmail.com", expected: "rtripath89@gmail.com" }
+    - { test_str: "RTRipath89@gmail.com", expected: "rtripath89@gmail.com" }

--- a/roles/ood_auth_regex/tasks/testing.yaml
+++ b/roles/ood_auth_regex/tasks/testing.yaml
@@ -1,0 +1,10 @@
+---
+- name: Testing regex file
+  command: /opt/ood/ood_auth_map/bin/uab_ood_auth.regex "{{ test_str }}"
+  register: result
+  ignore_errors: yes
+
+- assert:
+    that:
+      - result.stdout == expected
+    fail_msg: "Failed! Expected: {{ expected }}, but got: {{ result.stdout }}"


### PR DESCRIPTION
Since it's called `uab_ood_auth` I change default regex pattern to be `^(.+)@uab(mc)?.edu$` for uab
Still using Helpers provided by upstream.
The helpers return nil if pattern not found so the next line will put non-uab account back as `sys_user` and downcase
Run `getent passwd` to find out if the `sys_user` exists on cheaha