### PR TITLE
added rewrite condition for uab.edu user OR XIAS user

### DIFF
--- a/roles/ood_user_reg_cloud/templates/user-reg_conf_shib.j2
+++ b/roles/ood_user_reg_cloud/templates/user-reg_conf_shib.j2
@@ -8,11 +8,12 @@ ProxyPass /static http://127.0.0.1:8000/static
 ProxyPassReverse /static http://127.0.0.1:8000/static
 
 <Location /register-self>
+        RewriteEngine on
         AuthType shibboleth
         ShibRequestSetting requireSession 1
         Require valid-user
         RewriteCond %{IS_SUBREQ} ^false$
-        RewriteCond %{LA-U:REMOTE_USER} "([a-zA-Z0-9_.+-]+)@uab.edu$" [OR]
+        RewriteCond %{LA-U:REMOTE_USER} "([\w.+-]+)@uab\.edu$" [OR]
         RewriteCond %{LA-U:REMOTE_USER} "urn:mace:incommon:uab.edu!https://uabgrid.uab.edu/shibboleth!(.+)$"
         RewriteRule . - [E=RU:%1]
         RequestHeader set REMOTE_USER %{RU}e

--- a/roles/ood_user_reg_cloud/templates/user-reg_conf_shib.j2
+++ b/roles/ood_user_reg_cloud/templates/user-reg_conf_shib.j2
@@ -13,7 +13,7 @@ ProxyPassReverse /static http://127.0.0.1:8000/static
         ShibRequestSetting requireSession 1
         Require valid-user
         RewriteCond %{IS_SUBREQ} ^false$
-        RewriteCond %{LA-U:REMOTE_USER} "([\w.+-]+)@uab\.edu$" [OR]
+        RewriteCond %{LA-U:REMOTE_USER} "([^!]+)@uab\.edu$" [OR]
         RewriteCond %{LA-U:REMOTE_USER} "urn:mace:incommon:uab.edu!https://uabgrid.uab.edu/shibboleth!(.+)$"
         RewriteRule . - [E=RU:%1]
         RequestHeader set REMOTE_USER %{RU}e

--- a/roles/ood_user_reg_cloud/templates/user-reg_conf_shib.j2
+++ b/roles/ood_user_reg_cloud/templates/user-reg_conf_shib.j2
@@ -12,7 +12,8 @@ ProxyPassReverse /static http://127.0.0.1:8000/static
         ShibRequestSetting requireSession 1
         Require valid-user
         RewriteCond %{IS_SUBREQ} ^false$
-        RewriteCond %{LA-U:REMOTE_USER} "^([a-z]+)@samltest.id$"
+        RewriteCond %{LA-U:REMOTE_USER} "([a-zA-Z0-9_.+-]+)@uab.edu$" [OR]
+        RewriteCond %{LA-U:REMOTE_USER} "urn:mace:incommon:uab.edu!https://uabgrid.uab.edu/shibboleth!(.+)$"
         RewriteRule . - [E=RU:%1]
         RequestHeader set REMOTE_USER %{RU}e
         RewriteCond %{IS_SUBREQ} ^false$


### PR DESCRIPTION
1. Added RewriteEngine on
2. Added Rewrite rule regex for UAB users  ([\w.+-]+)@uab\.edu$
3. Added  Rewrite rule regex for XIAS users urn:mace:incommon:uab.edu!https://uabgrid.uab.edu/shibboleth!(.+)$