### PR TITLE
Fix version of SAS form

### DIFF
--- a/roles/ood_sas/templates/form.yml
+++ b/roles/ood_sas/templates/form.yml
@@ -33,8 +33,8 @@ attributes:
       - [ "largemem", "largemem" ]
       - [ "largemem-long", "largemem-long" ]
       - [ "amd-hdr100", "amd-hdr100" ]
-  
-version:
+
+  version:
     widget: select
     label: "SAS version"
     help: "This defines the version of SAS you want to load."


### PR DESCRIPTION
Version in SAS form should be a drop-down selection but it's showing as text input.