### PR TITLE
Rstudio env fix

### DIFF
--- a/roles/ood_updated_rstudio/files/script.sh.erb.j2
+++ b/roles/ood_updated_rstudio/files/script.sh.erb.j2
@@ -18,6 +18,7 @@ export RSTUDIO_AUTH="${PWD}/bin/auth"
 
 # Generate an `rsession` wrapper script
 export RSESSION_WRAPPER_FILE="${PWD}/rsession.sh"
+export RSESSION_ENV_FILE="${PWD}/rsession_env"
 (
 umask 077
 sed 's/^ \{2\}//' > "${RSESSION_WRAPPER_FILE}" << EOL

--- a/roles/ood_updated_rstudio/files/script.sh.erb.j2
+++ b/roles/ood_updated_rstudio/files/script.sh.erb.j2
@@ -21,12 +21,15 @@ export RSESSION_WRAPPER_FILE="${PWD}/rsession.sh"
 export RSESSION_ENV_FILE="${PWD}/rsession_env"
 (
 umask 077
+env | sed 's/^/export /' >> ${RSESSION_ENV_FILE}
 sed 's/^ \{2\}//' > "${RSESSION_WRAPPER_FILE}" << EOL
   #!/usr/bin/env bash
 
   # Log all output from this script
   export RSESSION_LOG_FILE="${PWD}/rsession.log"
   exec &>>"\${RSESSION_LOG_FILE}"
+
+  source ${RSESSION_ENV_FILE}
 
   # Launch the original command
   echo "Launching rsession..."


### PR DESCRIPTION
By default, Rstudio does not inherit the environment from where it's launched.
This PR let Rstudio use the same environment set by R module. 