### PR TITLE
Update site documentation url

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -259,7 +259,7 @@
   scratch_path: "/data/scratch"
   user_data_path: "/data/user"
   local_scratch_path: "/scratch"
-  docs_url: "https://uabrc.github.io"
+  docs_url: "https://docs.rc.uab.edu"
 
 # User Registration
   enable_user_reg: true


### PR DESCRIPTION
Move variable to using new docs.rc.uab.edu url available with the cname record to uabrc.github.io.